### PR TITLE
sync headers fetch progress

### DIFF
--- a/syncnotification.go
+++ b/syncnotification.go
@@ -108,7 +108,7 @@ func (mw *MultiWallet) fetchHeadersProgress(lastFetchedHeaderHeight int32, lastF
 
 	headersLeftToFetch := mw.estimateBlockHeadersCountAfter(lastFetchedHeaderTime)
 	totalHeadersToFetch := lastFetchedHeaderHeight + headersLeftToFetch
-	headersFetchedSoFar := mw.syncData.beginFetchTimeStamp
+	headersFetchedSoFar := mw.syncData.activeSyncData.startHeaderHeight
 	headersFetchProgress := float64(headersFetchedSoFar) / float64(totalHeadersToFetch)
 	// todo: above equation is potentially flawed because `lastFetchedHeaderHeight`
 	// may not be the total number of headers fetched so far in THIS sync operation.

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -108,7 +108,8 @@ func (mw *MultiWallet) fetchHeadersProgress(lastFetchedHeaderHeight int32, lastF
 
 	headersLeftToFetch := mw.estimateBlockHeadersCountAfter(lastFetchedHeaderTime)
 	totalHeadersToFetch := lastFetchedHeaderHeight + headersLeftToFetch
-	headersFetchProgress := float64(lastFetchedHeaderHeight) / float64(totalHeadersToFetch)
+	headersFetchedSoFar := mw.syncData.beginFetchTimeStamp
+	headersFetchProgress := float64(headersFetchedSoFar) / float64(totalHeadersToFetch)
 	// todo: above equation is potentially flawed because `lastFetchedHeaderHeight`
 	// may not be the total number of headers fetched so far in THIS sync operation.
 	// it may include headers previously fetched.


### PR DESCRIPTION
**Fixes** issue #95 

The pr was created to determine the actual number of headers fetched in the sync operation and use it to ascertain fetch progress.