### PR TITLE
prevent more than one wallet from using the same seed

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -33,6 +33,7 @@ const (
 	ErrAddressDiscoveryNotDone      = "address_discovery_not_done"
 	ErrChangingPassphrase           = "err_changing_passphrase"
 	ErrSavingWallet                 = "err_saving_wallet"
+	ErrSeedExists                   = "wallet_seed_exists"
 )
 
 // todo, should update this method to translate more error kinds.

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -405,10 +405,19 @@ func (mw *MultiWallet) saveNewWallet(wallet *Wallet, setupWallet func() error) (
 		return nil, errors.New(ErrExist)
 	}
 
+	// Check if any of the other wallets has the same seed with this wallet
+	// If so, return an error 
+	for _, wal := range mw.wallets {
+		if wal.Seed == wallet.Seed {
+			return nil, errors.New(ErrSeedExists)
+		}
+	}
+
 	if mw.IsConnectedToDecredNetwork() {
 		mw.CancelSync()
 		defer mw.SpvSync()
 	}
+
 	// Perform database save operations in batch transaction
 	// for automatic rollback if error occurs at any point.
 	err = mw.batchDbTransaction(func(db storm.Node) error {


### PR DESCRIPTION
This adds a feature that prevents more than one wallet from using the same seed.

Fixes #132 