### PR TITLE
fix sync progress calculation error

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -297,7 +297,7 @@ func (s *Syncer) Run(ctx context.Context) error {
 	for id, w := range s.wallets {
 		tipHash, tipHeight := w.MainChainTip(ctx)
 		log.Infof("[%d] Headers synced through block %v height %d", id, &tipHash, tipHeight)
-		
+
 		rescanPoint, err := w.RescanPoint(ctx)
 		if err != nil {
 			return err

--- a/sync.go
+++ b/sync.go
@@ -54,7 +54,8 @@ type activeSyncData struct {
 
 	rescanStartTime int64
 
-	totalInactiveSeconds int64
+	totalInactiveSeconds     int64
+	totalFetchedHeadersCount int32
 }
 
 const (

--- a/sync.go
+++ b/sync.go
@@ -87,6 +87,7 @@ func (mw *MultiWallet) initActiveSyncData() {
 		headersFetchTimeSpent:     -1,
 		addressDiscoveryStartTime: -1,
 		totalDiscoveryTimeSpent:   -1,
+		totalFetchedHeadersCount:  0,
 	}
 	mw.syncData.mu.Unlock()
 }

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -59,6 +59,7 @@ func (mw *MultiWallet) fetchHeadersStarted(peerInitialHeight int32) {
 
 	mw.syncData.mu.RLock()
 	headersFetchingStarted := mw.syncData.beginFetchTimeStamp != -1
+	mw.syncData.totalFetchedHeadersCount = 0
 	showLogs := mw.syncData.showLogs
 	mw.syncData.mu.RUnlock()
 
@@ -106,9 +107,13 @@ func (mw *MultiWallet) fetchHeadersProgress(lastFetchedHeaderHeight int32, lastF
 		}
 	}
 
+	if lastFetchedHeaderHeight > mw.syncData.activeSyncData.startHeaderHeight {
+		mw.syncData.activeSyncData.totalFetchedHeadersCount = lastFetchedHeaderHeight - mw.syncData.activeSyncData.startHeaderHeight
+	}
+
 	headersLeftToFetch := mw.estimateBlockHeadersCountAfter(lastFetchedHeaderTime)
 	totalHeadersToFetch := lastFetchedHeaderHeight + headersLeftToFetch
-	headersFetchProgress := float64(lastFetchedHeaderHeight) / float64(totalHeadersToFetch)
+	headersFetchProgress := float64(mw.syncData.activeSyncData.totalFetchedHeadersCount) / float64(totalHeadersToFetch)
 	// todo: above equation is potentially flawed because `lastFetchedHeaderHeight`
 	// may not be the total number of headers fetched so far in THIS sync operation.
 	// it may include headers previously fetched.

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -59,7 +59,6 @@ func (mw *MultiWallet) fetchHeadersStarted(peerInitialHeight int32) {
 
 	mw.syncData.mu.RLock()
 	headersFetchingStarted := mw.syncData.beginFetchTimeStamp != -1
-	mw.syncData.totalFetchedHeadersCount = 0
 	showLogs := mw.syncData.showLogs
 	mw.syncData.mu.RUnlock()
 
@@ -79,6 +78,7 @@ func (mw *MultiWallet) fetchHeadersStarted(peerInitialHeight int32) {
 	mw.syncData.activeSyncData.syncStage = HeadersFetchSyncStage
 	mw.syncData.activeSyncData.beginFetchTimeStamp = time.Now().Unix()
 	mw.syncData.activeSyncData.startHeaderHeight = lowestBlockHeight
+	mw.syncData.totalFetchedHeadersCount = 0
 	mw.syncData.mu.Unlock()
 
 	if showLogs {
@@ -107,6 +107,9 @@ func (mw *MultiWallet) fetchHeadersProgress(lastFetchedHeaderHeight int32, lastF
 		}
 	}
 
+	// lock the mutex before reading and writing to mw.syncData.*
+	mw.syncData.mu.Lock()
+
 	if lastFetchedHeaderHeight > mw.syncData.activeSyncData.startHeaderHeight {
 		mw.syncData.activeSyncData.totalFetchedHeadersCount = lastFetchedHeaderHeight - mw.syncData.activeSyncData.startHeaderHeight
 	}
@@ -120,9 +123,6 @@ func (mw *MultiWallet) fetchHeadersProgress(lastFetchedHeaderHeight int32, lastF
 	// probably better to compare number of headers fetched so far in THIS sync operation
 	// against the estimated number of headers left to fetch in THIS sync operation
 	// in order to determine the headers fetch progress so far in THIS sync operation.
-
-	// lock the mutex before reading and writing to mw.syncData.*
-	mw.syncData.mu.Lock()
 
 	// If there was some period of inactivity,
 	// assume that this process started at some point in the future,

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -194,6 +194,7 @@ func (mw *MultiWallet) fetchHeadersFinished() {
 	}
 
 	mw.syncData.activeSyncData.startHeaderHeight = -1
+	mw.syncData.totalFetchedHeadersCount = 0
 	mw.syncData.activeSyncData.headersFetchTimeSpent = time.Now().Unix() - mw.syncData.beginFetchTimeStamp
 
 	// If there is some period of inactivity reported at this stage,


### PR DESCRIPTION
This correctly calculates the progress of sync headers fetch operation. It achieves this by comparing the total headers fetched in the current sync operation against estimated number of headers left to be fetched.


Fixes #95 