### PR TITLE
verify address before adding to send destination

### DIFF
--- a/txauthor.go
+++ b/txauthor.go
@@ -31,12 +31,19 @@ func (mw *MultiWallet) NewUnsignedTx(sourceWallet *Wallet, sourceAccountNumber i
 	}
 }
 
-func (tx *TxAuthor) AddSendDestination(address string, atomAmount int64, sendMax bool) {
+func (tx *TxAuthor) AddSendDestination(address string, atomAmount int64, sendMax bool) error {
+	_, err := dcrutil.DecodeAddress(address, tx.sourceWallet.chainParams)
+	if err != nil {
+		return err
+	}
+
 	tx.destinations = append(tx.destinations, TransactionDestination{
 		Address:    address,
 		AtomAmount: atomAmount,
 		SendMax:    sendMax,
 	})
+
+	return nil
 }
 
 func (tx *TxAuthor) UpdateSendDestination(index int, address string, atomAmount int64, sendMax bool) {

--- a/txauthor.go
+++ b/txauthor.go
@@ -34,7 +34,7 @@ func (mw *MultiWallet) NewUnsignedTx(sourceWallet *Wallet, sourceAccountNumber i
 func (tx *TxAuthor) AddSendDestination(address string, atomAmount int64, sendMax bool) error {
 	_, err := dcrutil.DecodeAddress(address, tx.sourceWallet.chainParams)
 	if err != nil {
-		return err
+		return translateError(err)
 	}
 
 	tx.destinations = append(tx.destinations, TransactionDestination{


### PR DESCRIPTION
This PR verifies an address passed to the ```AddSendDestination``` function. It returns an error if the address is invalid. 

Fixes #100 