### PR TITLE
fix hang on sync canceling

### DIFF
--- a/multiwallet.go
+++ b/multiwallet.go
@@ -82,7 +82,6 @@ func NewMultiWallet(rootDir, dbDriver, netType string) (*MultiWallet, error) {
 		chainParams: chainParams,
 		wallets:     make(map[int]*Wallet),
 		syncData: &syncData{
-			syncCanceled:          make(chan struct{}),
 			syncProgressListeners: make(map[string]SyncProgressListener),
 		},
 		txAndBlockNotificationListeners: make(map[string]TxAndBlockNotificationListener),

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -82,7 +82,7 @@ func NewMultiWallet(rootDir, dbDriver, netType string) (*MultiWallet, error) {
 		chainParams: chainParams,
 		wallets:     make(map[int]*Wallet),
 		syncData: &syncData{
-			syncCanceled:          make(chan bool),
+			syncCanceled:          make(chan struct{}),
 			syncProgressListeners: make(map[string]SyncProgressListener),
 		},
 		txAndBlockNotificationListeners: make(map[string]TxAndBlockNotificationListener),

--- a/sync.go
+++ b/sync.go
@@ -24,7 +24,7 @@ type syncData struct {
 	syncing      bool
 	cancelSync   context.CancelFunc
 	cancelRescan context.CancelFunc
-	syncCanceled chan bool
+	syncCanceled chan struct{}
 
 	// Flag to notify syncCanceled callback if the sync was canceled so as to be restarted.
 	restartSyncRequested bool
@@ -250,7 +250,7 @@ func (mw *MultiWallet) SpvSync() error {
 			if syncError == context.DeadlineExceeded {
 				mw.notifySyncError(errors.Errorf("SPV synchronization deadline exceeded: %v", syncError))
 			} else if syncError == context.Canceled {
-				mw.syncData.syncCanceled <- true
+				close(mw.syncData.syncCanceled)
 				mw.notifySyncCanceled()
 			} else {
 				mw.notifySyncError(syncError)

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -519,6 +519,7 @@ func (mw *MultiWallet) resetSyncData() {
 	mw.syncData.syncing = false
 	mw.syncData.synced = false
 	mw.syncData.cancelSync = nil
+	mw.syncData.syncCanceled = nil
 	mw.syncData.activeSyncData = nil
 	mw.syncData.mu.Unlock()
 


### PR DESCRIPTION
This addresses sync canceling hanging forever at `Address manager shutting down`. This would occur when both `mw.listenForTransactions()` and `mw.CancelSync()` were waiting on the `syncCanceled` channel.

fixes #141 