### PR TITLE
Fix incorrect account balance bug

### DIFF
--- a/multiwallet.go
+++ b/multiwallet.go
@@ -139,6 +139,7 @@ func (mw *MultiWallet) Shutdown() {
 	if logRotator != nil {
 		log.Info("Shutting down log rotator")
 		logRotator.Close()
+		log.Info("Shutdown log rotator successfully")
 	}
 }
 


### PR DESCRIPTION
This fixes a bug that causes the LockedByTickets balance to always be 0 due to incomplete information returned by the badger database driver and it's caused by the [cursor](https://github.com/decred/dcrwallet/blob/master/wallet/udb/txmined.go#L3546) used to iterate unspent ticket commitments. The items in the database are grouped by prefixes(technically database tables), when iterating the unspent ticket commitments the cursor found an item with a another prefix an assumed the iteration was done meanwhile it could easily skip that to find all the required data.
Closes #154 