### PR TITLE
Add PeerInfo() to get a list of connected spv peers

### DIFF
--- a/types.go
+++ b/types.go
@@ -63,6 +63,17 @@ type Accounts struct {
 	CurrentBlockHeight int32
 }
 
+type PeerInfo struct {
+	ID             int32  `json:"id"`
+	Addr           string `json:"addr"`
+	AddrLocal      string `json:"addr_local"`
+	Services       string `json:"services"`
+	Version        uint32 `json:"version"`
+	SubVer         string `json:"sub_ver"`
+	StartingHeight int64  `json:"starting_height"`
+	BanScore       int32  `json:"ban_score"`
+}
+
 /** begin sync-related types */
 
 type SyncProgressListener interface {


### PR DESCRIPTION
`PeerInfo()` returns information about currently connected spv peers in json.
```
[
    {
        "id": 1,
        "addr": "127.0.0.1:19108",
        "addr_local": "127.0.0.1:53402",
        "services": "00000005",
        "version": 8,
        "sub_ver": "/dcrwire:0.4.0/dcrd:1.7.0(pre)/",
        "starting_height": 559536,
        "ban_score": 0
    }
]
```