### PR TITLE
account mixer: add ReadyToMix to determine if wallet is ready to mix

### DIFF
--- a/account_mixer.go
+++ b/account_mixer.go
@@ -10,34 +10,65 @@ import (
 	"github.com/decred/dcrd/dcrutil/v3"
 )
 
-const smalletSplitPoint = 000.00262144
+const (
+	smalletSplitPoint  = 000.00262144
+	ShuffleServer      = "cspp.decred.org"
+	ShufflePort        = "15760"
+	MixedAccountBranch = 0
+)
 
 func (mw *MultiWallet) SetAccountMixerNotification(accountMixerNotificationListener AccountMixerNotificationListener) {
 	mw.accountMixerNotificationListener = accountMixerNotificationListener
 }
 
-func (wallet *Wallet) SetAccountMixerConfig(mixedAccount, changeAccount int32) error {
+func (wallet *Wallet) SetAccountMixerConfig(mixedAccount, unmixedAccount, privPass string) error {
 
 	accountMixerConfigSet := wallet.ReadBoolConfigValueForKey(AccountMixerConfigSet, false)
 	if accountMixerConfigSet {
 		return errors.New(ErrInvalid)
 	}
 
-	_, err := wallet.GetAccount(mixedAccount)
+	if wallet.HasAccount(mixedAccount) || wallet.HasAccount(unmixedAccount) {
+		return errors.New(ErrExist)
+	}
+
+	mixedAccountNumber, err := wallet.NextAccount(mixedAccount, []byte(privPass))
 	if err != nil {
 		return err
 	}
 
-	_, err = wallet.GetAccount(changeAccount)
+	unmixedAccountNumber, err := wallet.NextAccount(unmixedAccount, []byte(privPass))
 	if err != nil {
 		return err
 	}
 
-	wallet.SetInt32ConfigValueForKey(AccountMixerMixedAccount, mixedAccount)
-	wallet.SetInt32ConfigValueForKey(AccountMixerChangeAccount, changeAccount)
+	wallet.SetInt32ConfigValueForKey(AccountMixerMixedAccount, mixedAccountNumber)
+	wallet.SetInt32ConfigValueForKey(AccountMixerUnmixedAccount, unmixedAccountNumber)
 	wallet.SetBoolConfigValueForKey(AccountMixerConfigSet, true)
 
 	return nil
+}
+
+func (wallet *Wallet) ClearMixerConfig() {
+	wallet.SetInt32ConfigValueForKey(AccountMixerMixedAccount, -1)
+	wallet.SetInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
+	wallet.SetBoolConfigValueForKey(AccountMixerConfigSet, false)
+}
+
+func (mw *MultiWallet) ReadyToMix(walletID int) (bool, error) {
+	wallet := mw.WalletWithID(walletID)
+	if wallet == nil {
+		return false, errors.New(ErrNotExist)
+	}
+
+	unmixedAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
+
+	hasMixableOutput, err := wallet.accountHasMixableOutput(unmixedAccount)
+	if err != nil {
+		return false, translateError(err)
+	}
+
+	return hasMixableOutput, nil
 }
 
 // StartAccountMixer starts the automatic account mixer
@@ -55,9 +86,9 @@ func (mw *MultiWallet) StartAccountMixer(walletID int, walletPassphrase string) 
 	tb := ticketbuyer.New(wallet.internal)
 
 	mixedAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerMixedAccount, -1)
-	changeAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerChangeAccount, -1)
+	unmixedAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
 
-	hasMixableOutput, err := wallet.accountHasMixableOutput(changeAccount)
+	hasMixableOutput, err := wallet.accountHasMixableOutput(unmixedAccount)
 	if err != nil {
 		return translateError(err)
 	} else if !hasMixableOutput {
@@ -65,10 +96,10 @@ func (mw *MultiWallet) StartAccountMixer(walletID int, walletPassphrase string) 
 	}
 
 	tb.AccessConfig(func(c *ticketbuyer.Config) {
-		c.MixedAccountBranch = 0
+		c.MixedAccountBranch = MixedAccountBranch
 		c.MixedAccount = uint32(mixedAccount)
-		c.ChangeAccount = uint32(changeAccount)
-		c.CSPPServer = "cspp.decred.org:15760"
+		c.ChangeAccount = uint32(unmixedAccount)
+		c.CSPPServer = ShuffleServer + ":" + ShufflePort
 		c.BuyTickets = false
 		c.MixChange = true
 	})
@@ -140,12 +171,12 @@ func (wallet *Wallet) accountHasMixableOutput(accountNumber int32) (bool, error)
 	}
 
 	if !hasMixableOutput {
-		accoutnName, err := wallet.AccountName(accountNumber)
+		accountName, err := wallet.AccountName(accountNumber)
 		if err != nil {
 			return hasMixableOutput, nil
 		}
 
-		lockedOutpoints, err := wallet.internal.LockedOutpoints(wallet.shutdownContext(), accoutnName)
+		lockedOutpoints, err := wallet.internal.LockedOutpoints(wallet.shutdownContext(), accountName)
 		if err != nil {
 			return hasMixableOutput, nil
 		}

--- a/account_mixer.go
+++ b/account_mixer.go
@@ -30,12 +30,19 @@ func (wallet *Wallet) SetAccountMixerConfig(mixedAccount, unmixedAccount, privPa
 		return errors.New(ErrExist)
 	}
 
-	mixedAccountNumber, err := wallet.NextAccount(mixedAccount, []byte(privPass))
+	err := wallet.UnlockWallet([]byte(privPass))
 	if err != nil {
 		return err
 	}
 
-	unmixedAccountNumber, err := wallet.NextAccount(unmixedAccount, []byte(privPass))
+	defer wallet.LockWallet()
+
+	mixedAccountNumber, err := wallet.NextAccount(mixedAccount)
+	if err != nil {
+		return err
+	}
+
+	unmixedAccountNumber, err := wallet.NextAccount(unmixedAccount)
 	if err != nil {
 		return err
 	}

--- a/accounts.go
+++ b/accounts.go
@@ -183,13 +183,17 @@ func (wallet *Wallet) NextAccount(accountName string, privPass []byte) (int32, e
 
 	err := wallet.UnlockWallet(privPass)
 	if err != nil {
-		log.Error(err)
-		return 0, errors.New(ErrInvalidPassphrase)
+		return -1, err
 	}
 
-	accountNumber, err := wallet.internal.NextAccount(ctx, accountName)
+	defer wallet.LockWallet()
 
-	return int32(accountNumber), err
+	accountNumber, err := wallet.internal.NextAccount(ctx, accountName)
+	if err != nil {
+		return -1, err
+	}
+
+	return int32(accountNumber), nil
 }
 
 func (wallet *Wallet) RenameAccount(accountNumber int32, newName string) error {

--- a/accounts.go
+++ b/accounts.go
@@ -178,15 +178,24 @@ func (wallet *Wallet) UnspentOutputs(account int32) ([]*UnspentOutput, error) {
 	return unspentOutputs, nil
 }
 
-func (wallet *Wallet) NextAccount(accountName string, privPass []byte) (int32, error) {
-	ctx := wallet.shutdownContext()
-
+func (wallet *Wallet) CreateNewAccount(accountName string, privPass []byte) (int32, error) {
 	err := wallet.UnlockWallet(privPass)
 	if err != nil {
 		return -1, err
 	}
 
 	defer wallet.LockWallet()
+
+	return wallet.NextAccount(accountName)
+}
+
+func (wallet *Wallet) NextAccount(accountName string) (int32, error) {
+
+	if wallet.IsLocked() {
+		return -1, errors.New(ErrWalletLocked)
+	}
+
+	ctx := wallet.shutdownContext()
 
 	accountNumber, err := wallet.internal.NextAccount(ctx, accountName)
 	if err != nil {

--- a/accounts.go
+++ b/accounts.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"decred.org/dcrwallet/errors"
 	w "decred.org/dcrwallet/wallet"
@@ -180,16 +179,9 @@ func (wallet *Wallet) UnspentOutputs(account int32) ([]*UnspentOutput, error) {
 }
 
 func (wallet *Wallet) NextAccount(accountName string, privPass []byte) (int32, error) {
-	lock := make(chan time.Time, 1)
-	defer func() {
-		for i := range privPass {
-			privPass[i] = 0
-		}
-		lock <- time.Time{} // send matters, not the value
-	}()
-
 	ctx := wallet.shutdownContext()
-	err := wallet.internal.Unlock(ctx, privPass, lock)
+
+	err := wallet.UnlockWallet(privPass)
 	if err != nil {
 		log.Error(err)
 		return 0, errors.New(ErrInvalidPassphrase)

--- a/badgerdb/db.go
+++ b/badgerdb/db.go
@@ -641,7 +641,7 @@ func openDB(dbPath string, create bool) (walletdb.DB, error) {
 		WithValueLogLoadingMode(options.FileIO).
 		WithTableLoadingMode(options.FileIO).
 		WithValueLogFileSize(200 << 20).
-		WithMaxTableSize(64 << 20).
+		WithMaxTableSize(40 << 20).
 		WithLevelOneSize(200 << 20).
 		WithNumMemtables(1).
 		WithNumCompactors(1).

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ const (
 	// Error Codes
 	ErrInsufficientBalance          = "insufficient_balance"
 	ErrInvalid                      = "invalid"
+	ErrWalletLocked                 = "wallet_locked"
 	ErrWalletDatabaseInUse          = "wallet_db_in_use"
 	ErrWalletNotLoaded              = "wallet_not_loaded"
 	ErrWalletNameExist              = "wallet_name_exists"

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1455,7 +1455,7 @@ func (s *Syncer) handleMempool(ctx context.Context) error {
 				select {
 				case <-ctx.Done():
 				case <-time.After(mempoolEvictionTimeout):
-					s.mempool.Delete(txHash)
+					s.mempool.Delete(*txHash)
 				}
 			}()
 		case <-ctx.Done():

--- a/txandblocknotifications.go
+++ b/txandblocknotifications.go
@@ -98,7 +98,7 @@ func (mw *MultiWallet) RemoveTxAndBlockNotificationListener(uniqueIdentifier str
 func (mw *MultiWallet) checkWalletMixers() {
 	for _, wallet := range mw.wallets {
 		if wallet.IsAccountMixerActive() {
-			changeAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerChangeAccount, -1)
+			changeAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
 			hasMixableOutput, err := wallet.accountHasMixableOutput(changeAccount)
 			if err != nil {
 				log.Errorf("Error checking for mixable outputs: %v", err)

--- a/txandblocknotifications.go
+++ b/txandblocknotifications.go
@@ -98,14 +98,14 @@ func (mw *MultiWallet) RemoveTxAndBlockNotificationListener(uniqueIdentifier str
 func (mw *MultiWallet) checkWalletMixers() {
 	for _, wallet := range mw.wallets {
 		if wallet.IsAccountMixerActive() {
-			changeAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
-			hasMixableOutput, err := wallet.accountHasMixableOutput(changeAccount)
+			unmixedAccount := wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
+			hasMixableOutput, err := wallet.accountHasMixableOutput(unmixedAccount)
 			if err != nil {
 				log.Errorf("Error checking for mixable outputs: %v", err)
 			}
 
 			if !hasMixableOutput {
-				log.Infof("[%d] change account does not have a mixable output, stopping account mixer", wallet.ID)
+				log.Infof("[%d] unmixed account does not have a mixable output, stopping account mixer", wallet.ID)
 				err = mw.StopAccountMixer(wallet.ID)
 				if err != nil {
 					log.Errorf("Error stopping account mixer: %v", err)

--- a/txauthor.go
+++ b/txauthor.go
@@ -334,7 +334,7 @@ func (tx *TxAuthor) changeSource(ctx context.Context) (txauthor.ChangeSource, er
 
 		mixChange := tx.sourceWallet.ReadBoolConfigValueForKey(AccountMixerMixTxChange, false)
 		if mixChange {
-			changeAccount = uint32(tx.sourceWallet.ReadInt32ConfigValueForKey(AccountMixerChangeAccount, -1))
+			changeAccount = uint32(tx.sourceWallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1))
 		} else {
 			changeAccount = tx.sourceAccountNumber
 		}

--- a/txindex.go
+++ b/txindex.go
@@ -71,11 +71,11 @@ func (wallet *Wallet) IndexTransactions() error {
 		if err != nil {
 			log.Errorf("[%d] Post-indexing tx count error :%v", wallet.ID, err)
 		} else if count > 0 {
-			log.Debugf("[%d] Transaction index finished at %d, %d transaction(s) indexed in total", wallet.ID, txEndHeight, count)
+			log.Infof("[%d] Transaction index finished at %d, %d transaction(s) indexed in total", wallet.ID, txEndHeight, count)
 		}
 	}()
 
-	log.Debugf("[%d] Indexing transactions start height: %d, end height: %d", wallet.ID, beginHeight, endHeight)
+	log.Infof("[%d] Indexing transactions start height: %d, end height: %d", wallet.ID, beginHeight, endHeight)
 	return wallet.internal.GetTransactions(ctx, rangeFn, startBlock, endBlock)
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -219,6 +219,10 @@ func (wallet *Wallet) UnlockWallet(privPass []byte) error {
 }
 
 func (wallet *Wallet) LockWallet() {
+	if wallet.IsAccountMixerActive() {
+		log.Error("LockWallet ignored due to active account mixer")
+	}
+
 	if !wallet.internal.Locked() {
 		wallet.internal.Lock()
 	}

--- a/wallet_config.go
+++ b/wallet_config.go
@@ -6,10 +6,10 @@ import (
 )
 
 const (
-	AccountMixerConfigSet     = "account_mixer_config_set"
-	AccountMixerMixedAccount  = "account_mixer_mixed_account"
-	AccountMixerChangeAccount = "account_mixer_change_account"
-	AccountMixerMixTxChange   = "account_mixer_mix_tx_change"
+	AccountMixerConfigSet      = "account_mixer_config_set"
+	AccountMixerMixedAccount   = "account_mixer_mixed_account"
+	AccountMixerUnmixedAccount = "account_mixer_unmixed_account"
+	AccountMixerMixTxChange    = "account_mixer_mix_tx_change"
 )
 
 func (wallet *Wallet) SaveUserConfigValue(key string, value interface{}) {


### PR DESCRIPTION
- add ClearMixerConfig to reset account mixer config
- rename instances of 'Change' to 'Unmixed'
- remove wallet lock timeout when creating an account