### PR TITLE
tx index: rename old tx db to new walletdata db name

### DIFF
--- a/multiwallet.go
+++ b/multiwallet.go
@@ -362,7 +362,7 @@ func (mw *MultiWallet) LinkExistingWallet(walletName, walletDataDir, originalPub
 			return err
 		}
 
-		currentTxDbFilePath := filepath.Join(walletDataDir, "tx.db")
+		currentTxDbFilePath := filepath.Join(walletDataDir, walletdata.OldDbName)
 		newTxDbFilePath := filepath.Join(wallet.dataDir, walletdata.DbName)
 		if err := moveFile(currentTxDbFilePath, newTxDbFilePath); err != nil {
 			return err

--- a/wallet.go
+++ b/wallet.go
@@ -65,6 +65,10 @@ func (wallet *Wallet) prepare(rootDir string, chainParams *chaincfg.Params,
 
 	// open database for indexing transactions for faster loading
 	walletDataDBPath := filepath.Join(wallet.dataDir, walletdata.DbName)
+	oldTxDBPath := filepath.Join(wallet.dataDir, walletdata.OldDbName)
+	if exists, _ := fileExists(oldTxDBPath); exists {
+		moveFile(oldTxDBPath, walletDataDBPath)
+	}
 	wallet.walletDataDB, err = walletdata.Initialize(walletDataDBPath, &Transaction{}, &VspdTicketInfo{})
 	if err != nil {
 		log.Error(err.Error())

--- a/walletdata/db.go
+++ b/walletdata/db.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	DbName = "walletData.db"
+	DbName    = "walletData.db"
+	OldDbName = "tx.db"
 
 	TxBucketName = "TxIndexInfo"
 	KeyDbVersion = "DbVersion"


### PR DESCRIPTION
Following https://github.com/planetdecred/dcrlibwallet/pull/163, tx db name was renamed to `walletData.db` from `tx.db`. This change ensures any wallet with the old `tx.db` will get renamed to the new name.