### PR TITLE
Allow dcrlibwallet to use an external logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -98,16 +98,23 @@ func initLogRotator(logFile string) error {
 	return nil
 }
 
+// UseLoggers sets the subsystem logs to use the provided loggers.
+func UseLoggers(main, loaderLog, walletLog, tkbyLog,
+	syncLog, cmgrLog, amgrLog slog.Logger) {
+	log = main
+	loader.UseLogger(loaderLog)
+	wallet.UseLogger(walletLog)
+	udb.UseLogger(walletLog)
+	ticketbuyer.UseLogger(tkbyLog)
+	spv.UseLogger(syncLog)
+	p2p.UseLogger(syncLog)
+	connmgr.UseLogger(cmgrLog)
+	addrmgr.UseLogger(amgrLog)
+}
+
+// UseLogger sets the subsystem logs to use the provided logger.
 func UseLogger(logger slog.Logger) {
-	log = logger
-	loader.UseLogger(logger)
-	wallet.UseLogger(logger)
-	udb.UseLogger(logger)
-	ticketbuyer.UseLogger(logger)
-	spv.UseLogger(logger)
-	p2p.UseLogger(logger)
-	connmgr.UseLogger(logger)
-	addrmgr.UseLogger(logger)
+	UseLoggers(logger, logger, logger, logger, logger, logger, logger)
 }
 
 // RegisterLogger should be called before logRotator is initialized.

--- a/log.go
+++ b/log.go
@@ -98,6 +98,18 @@ func initLogRotator(logFile string) error {
 	return nil
 }
 
+func UseLogger(logger slog.Logger) {
+	log = logger
+	loader.UseLogger(logger)
+	wallet.UseLogger(logger)
+	udb.UseLogger(logger)
+	ticketbuyer.UseLogger(logger)
+	spv.UseLogger(logger)
+	p2p.UseLogger(logger)
+	connmgr.UseLogger(logger)
+	addrmgr.UseLogger(logger)
+}
+
 // RegisterLogger should be called before logRotator is initialized.
 func RegisterLogger(tag string) (slog.Logger, error) {
 	if logRotator != nil {


### PR DESCRIPTION
Currently dcrlibwallet uses its own internal log system which is fine but as dcrlibwallet is mostly used as a package and not a standalone program this doesn't allow programs that uses dcrlibwallet to control the logging (save for setting the log levels).

This pull request will allow external programs to use their own log systems in place of this internal system allowing greater control of logging output. 

For example, in [godcr](https://github.com/planetdecred/godcr) this will allow a cross platform way for the application to display a page showing the log output.

This doesn't replace the current system in any capacity, dcrlibwallet will still use its own system if no logger is used.