### PR TITLE
Index transaction everytime synced function is called

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (mw *MultiWallet) RescanBlocks(walletID int) error {
+	return mw.RescanBlocksFromHeight(walletID, 0)
+}
+
+func (mw *MultiWallet) RescanBlocksFromHeight(walletID int, startHeight int32) error {
 
 	wallet := mw.WalletWithID(walletID)
 	if wallet == nil {
@@ -45,7 +49,7 @@ func (mw *MultiWallet) RescanBlocks(walletID int) error {
 		}
 
 		progress := make(chan w.RescanProgress, 1)
-		go wallet.internal.RescanProgressFromHeight(ctx, netBackend, 0, progress)
+		go wallet.internal.RescanProgressFromHeight(ctx, netBackend, startHeight, progress)
 
 		rescanStartTime := time.Now().Unix()
 
@@ -98,7 +102,12 @@ func (mw *MultiWallet) RescanBlocks(walletID int) error {
 			}
 		}
 
-		err := wallet.reindexTransactions()
+		var err error
+		if startHeight == 0 {
+			err = wallet.reindexTransactions()
+		} else {
+			err = wallet.IndexTransactions()
+		}
 		if mw.blocksRescanProgressListener != nil {
 			mw.blocksRescanProgressListener.OnBlocksRescanEnded(walletID, err)
 		}

--- a/rescan.go
+++ b/rescan.go
@@ -106,6 +106,14 @@ func (mw *MultiWallet) RescanBlocksFromHeight(walletID int, startHeight int32) e
 		if startHeight == 0 {
 			err = wallet.reindexTransactions()
 		} else {
+			err = wallet.walletDataDB.SaveLastIndexPoint(startHeight)
+			if err != nil {
+				if mw.blocksRescanProgressListener != nil {
+					mw.blocksRescanProgressListener.OnBlocksRescanEnded(walletID, err)
+				}
+				return
+			}
+
 			err = wallet.IndexTransactions()
 		}
 		if mw.blocksRescanProgressListener != nil {

--- a/txindex.go
+++ b/txindex.go
@@ -1,10 +1,14 @@
 package dcrlibwallet
 
 import (
+	"errors"
+
 	w "decred.org/dcrwallet/wallet"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/planetdecred/dcrlibwallet/walletdata"
 )
+
+const defaultTxRecoveryBlocks int32 = 4000
 
 func (wallet *Wallet) IndexTransactions() error {
 	ctx := wallet.shutdownContext()
@@ -86,4 +90,41 @@ func (wallet *Wallet) reindexTransactions() error {
 	}
 
 	return wallet.IndexTransactions()
+}
+
+func (mw *MultiWallet) RecoverTransactions(walletId int) error {
+
+	if !mw.IsSynced() {
+		return errors.New(ErrNotConnected)
+	}
+
+	wallet := mw.WalletWithID(walletId)
+	if wallet == nil {
+		return errors.New(ErrNotExist)
+	}
+
+	log.Infof("[%d] Doing transaction recovery", walletId)
+
+	lastIndexBlock, err := wallet.walletDataDB.LastIndexPoint()
+	if err != nil {
+		return err
+	}
+
+	bestBlock := mw.GetBestBlock()
+	beginScanHeight := bestBlock.Height - defaultTxRecoveryBlocks // recover from the last txRecoveryBlocks
+	if lastIndexBlock < beginScanHeight {
+		// tx index last index block might be older than beginScanHeight
+		beginScanHeight = lastIndexBlock
+	}
+
+	if beginScanHeight < 0 {
+		beginScanHeight = 0
+	}
+
+	err = wallet.walletDataDB.SaveLastIndexPoint(beginScanHeight)
+	if err != nil {
+		return err
+	}
+
+	return mw.RescanBlocksFromHeight(walletId, beginScanHeight)
 }

--- a/txindex.go
+++ b/txindex.go
@@ -1,8 +1,6 @@
 package dcrlibwallet
 
 import (
-	"errors"
-
 	w "decred.org/dcrwallet/wallet"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/planetdecred/dcrlibwallet/walletdata"
@@ -90,41 +88,4 @@ func (wallet *Wallet) reindexTransactions() error {
 	}
 
 	return wallet.IndexTransactions()
-}
-
-func (mw *MultiWallet) RecoverTransactions(walletId int) error {
-
-	if !mw.IsSynced() {
-		return errors.New(ErrNotConnected)
-	}
-
-	wallet := mw.WalletWithID(walletId)
-	if wallet == nil {
-		return errors.New(ErrNotExist)
-	}
-
-	log.Infof("[%d] Doing transaction recovery", walletId)
-
-	lastIndexBlock, err := wallet.walletDataDB.LastIndexPoint()
-	if err != nil {
-		return err
-	}
-
-	bestBlock := mw.GetBestBlock()
-	beginScanHeight := bestBlock.Height - defaultTxRecoveryBlocks // recover from the last txRecoveryBlocks
-	if lastIndexBlock < beginScanHeight {
-		// tx index last index block might be older than beginScanHeight
-		beginScanHeight = lastIndexBlock
-	}
-
-	if beginScanHeight < 0 {
-		beginScanHeight = 0
-	}
-
-	err = wallet.walletDataDB.SaveLastIndexPoint(beginScanHeight)
-	if err != nil {
-		return err
-	}
-
-	return mw.RescanBlocksFromHeight(walletId, beginScanHeight)
 }

--- a/walletdata/save.go
+++ b/walletdata/save.go
@@ -51,6 +51,16 @@ func (db *DB) SaveOrUpdateVspdRecord(emptyTxPointer, record interface{}) (update
 	return
 }
 
+func (db *DB) LastIndexPoint() (int32, error) {
+	var endBlockHeight int32
+	err := db.walletDataDB.Get(TxBucketName, KeyEndBlock, &endBlockHeight)
+	if err != nil && err != storm.ErrNotFound {
+		return 0, err
+	}
+
+	return endBlockHeight, nil
+}
+
 func (db *DB) SaveLastIndexPoint(endBlockHeight int32) error {
 	err := db.walletDataDB.Set(TxBucketName, KeyEndBlock, &endBlockHeight)
 	if err != nil {


### PR DESCRIPTION
This fixes a bug where a received transaction does not show up until transaction indexing is done during manual rescan or next sync because sync notifications are ignored once the initial sync completed notification is received. The bug was fixed by indexing transactions whenever `synced` notification is received and all wallets are synced.
Closes #180 