### PR TITLE
Add function to get wallet db driver and declare db driver constants

### DIFF
--- a/multiwallet.go
+++ b/multiwallet.go
@@ -22,6 +22,11 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const (
+	DBDriverBadger = "badgerdb"
+	DBDriverBolt   = "bdb"
+)
+
 type MultiWallet struct {
 	dbDriver string
 	rootDir  string

--- a/wallet.go
+++ b/wallet.go
@@ -125,6 +125,10 @@ func (wallet *Wallet) NetType() string {
 	return wallet.chainParams.Name
 }
 
+func (wallet *Wallet) DBDriver() string {
+	return wallet.DbDriver
+}
+
 func (wallet *Wallet) WalletExists() (bool, error) {
 	return wallet.loader.WalletExists()
 }


### PR DESCRIPTION
The `DBDriver` function will help the client app know what database driver the wallet was created with.