### PR TITLE
modified opts.TableLoadingMode param in badger to reduce memory usuage

### DIFF
--- a/badgerdb/db.go
+++ b/badgerdb/db.go
@@ -648,7 +648,7 @@ func openDB(dbPath string, create bool) (walletdb.DB, error) {
 	opts.Dir = dbPath
 	opts.ValueDir = dbPath
 	opts.ValueLogLoadingMode = options.FileIO
-	opts.TableLoadingMode = options.MemoryMap
+	opts.TableLoadingMode = options.FileIO
 	opts.ValueLogFileSize = 209715200
 	opts.MaxTableSize = 40000000
 	opts.LevelOneSize = 209715200


### PR DESCRIPTION
Modified `opts.TableLoadingMode` param from `options.MemoryMap` to  `options.FileIO`

The default loading mode is memory-map which means data will be loaded into RAM when it is accessed. Using FileIO mode could severely affect your read speed but it should reduce the RAM usage.