### PR TITLE
[release-v1.5] Index transaction everytime synced function is called

### DIFF
--- a/syncnotification.go
+++ b/syncnotification.go
@@ -530,11 +530,37 @@ func (mw *MultiWallet) resetSyncData() {
 }
 
 func (mw *MultiWallet) synced(walletID int, synced bool) {
+
+	indexTransactions := func() {
+		// begin indexing transactions after sync is completed,
+		// syncProgressListeners.OnSynced() will be invoked after transactions are indexed
+		var txIndexing errgroup.Group
+		for _, wallet := range mw.wallets {
+			txIndexing.Go(wallet.IndexTransactions)
+		}
+
+		go func() {
+			err := txIndexing.Wait()
+			if err != nil {
+				log.Errorf("Tx Index Error: %v", err)
+			}
+
+			for _, syncProgressListener := range mw.syncProgressListeners() {
+				if synced {
+					syncProgressListener.OnSyncCompleted()
+				} else {
+					syncProgressListener.OnSyncCanceled(false)
+				}
+			}
+		}()
+	}
+
 	mw.syncData.mu.RLock()
 	allWalletsSynced := mw.syncData.synced
 	mw.syncData.mu.RUnlock()
 
 	if allWalletsSynced && synced {
+		indexTransactions()
 		return
 	}
 
@@ -557,26 +583,6 @@ func (mw *MultiWallet) synced(walletID int, synced bool) {
 		mw.syncData.synced = true
 		mw.syncData.mu.Unlock()
 
-		// begin indexing transactions after sync is completed,
-		// syncProgressListeners.OnSynced() will be invoked after transactions are indexed
-		var txIndexing errgroup.Group
-		for _, wallet := range mw.wallets {
-			txIndexing.Go(wallet.IndexTransactions)
-		}
-
-		go func() {
-			err := txIndexing.Wait()
-			if err != nil {
-				log.Errorf("Tx Index Error: %v", err)
-			}
-
-			for _, syncProgressListener := range mw.syncProgressListeners() {
-				if synced {
-					syncProgressListener.OnSyncCompleted()
-				} else {
-					syncProgressListener.OnSyncCanceled(false)
-				}
-			}
-		}()
+		indexTransactions()
 	}
 }


### PR DESCRIPTION
This fixes a bug where a received transaction does not show up until transaction indexing is done during manual rescan or next sync because sync notifications are ignored once the initial sync completed notification is received. The bug was fixed by indexing transactions whenever `synced` notification is received and all wallets are synced.