### PR TITLE
Remove db driver function to avoid gomobile functions conflict

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -125,10 +125,6 @@ func (wallet *Wallet) NetType() string {
 	return wallet.chainParams.Name
 }
 
-func (wallet *Wallet) DBDriver() string {
-	return wallet.DbDriver
-}
-
 func (wallet *Wallet) WalletExists() (bool, error) {
 	return wallet.loader.WalletExists()
 }


### PR DESCRIPTION
This pr removes the `DbDriver` function added by https://github.com/planetdecred/dcrlibwallet/pull/182, the function already gets added by gomobile during the build and it causes a function name conflict.