### PR TITLE
Fix bugs when updating proposals

### DIFF
--- a/politeia.go
+++ b/politeia.go
@@ -61,13 +61,24 @@ func (p *Politeia) saveOrOverwiteProposal(proposal *Proposal) error {
 
 // GetProposalsRaw fetches and returns a proposals from the db
 func (p *Politeia) GetProposalsRaw(category int32, offset, limit int32, newestFirst bool) ([]Proposal, error) {
+	return p.getProposalsRaw(category, offset, limit, newestFirst, false)
+}
+
+func (p *Politeia) getProposalsRaw(category int32, offset, limit int32, newestFirst bool, skipAbandoned bool) ([]Proposal, error) {
 
 	var query storm.Query
 	switch category {
 	case ProposalCategoryAll:
-		query = p.mwRef.db.Select(
-			q.True(),
-		)
+
+		if skipAbandoned {
+			query = p.mwRef.db.Select(
+				q.Not(q.Eq("Category", ProposalCategoryAbandoned)),
+			)
+		} else {
+			query = p.mwRef.db.Select(
+				q.True(),
+			)
+		}
 	default:
 		query = p.mwRef.db.Select(
 			q.Eq("Category", category),

--- a/types.go
+++ b/types.go
@@ -304,7 +304,7 @@ type VSPTicketPurchaseInfo struct {
 /** begin politeia types */
 type Proposal struct {
 	ID               int    `storm:"id,increment"`
-	Token            string `json:"token" storm:"index"`
+	Token            string `json:"token" storm:"unique"`
 	Category         int32  `json:"category" storm:"index"`
 	Name             string `json:"name"`
 	State            int32  `json:"state"`


### PR DESCRIPTION
Closes #179 
This pr fixes a bug where a proposal is shown under the wrong category which happens after a proposal is updated. The following bugs are fixed by this pr:
- Skip abandoned proposals when checking for updates.
- Fix incorrect no votes & category on an updated proposal.
- Fix false positive deep equal comparison by setting updated proposal id.
- Set Token property as unique under Proposal struct.