### PR TITLE
Set amount for ticket & revoke transactions

### DIFF
--- a/decodetx.go
+++ b/decodetx.go
@@ -40,6 +40,11 @@ func DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chaincfg.Params) (
 	// ticketSpentHash will be empty if this isn't a vote tx
 	if stake.IsSSRtx(msgTx) {
 		ticketSpentHash = msgTx.TxIn[0].PreviousOutPoint.Hash.String()
+		// set first tx input ss amount for revoked txs
+		amount = msgTx.TxIn[0].ValueIn
+	} else if stake.IsSStx(msgTx) {
+		// set first tx output as amount for ticket txs
+		amount = msgTx.TxOut[0].Value
 	}
 
 	isMixedTx, mixDenom, mixCount := txhelpers.IsMixTx(msgTx)


### PR DESCRIPTION
The amount for ticket & revoke transaction was not set and it made the transaction decoder use the transaction fee as the amount instead of the ticket purchase amount. The pr fixes that by setting the amount to the appropriate transaction input/output.

Closes #177 