### PR TITLE
fix wrong total balance being returned

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -43,7 +43,7 @@ func (wallet *Wallet) GetAccountsRaw() (*Accounts, error) {
 			Number:           int32(a.AccountNumber),
 			Name:             a.AccountName,
 			Balance:          balance,
-			TotalBalance:     int64(a.TotalBalance),
+			TotalBalance:     balance.Total,
 			ExternalKeyCount: int32(a.LastUsedExternalIndex + AddressGapLimit), // Add gap limit
 			InternalKeyCount: int32(a.LastUsedInternalIndex + AddressGapLimit),
 			ImportedKeyCount: int32(a.ImportedKeyCount),


### PR DESCRIPTION
The total balance returned was including voting authority, hence showing the user an incorrect watch only wallet balance.

This PR fixes that