### PR TITLE
Add Mixed transaction type and filter 

### DIFF
--- a/decodetx.go
+++ b/decodetx.go
@@ -79,10 +79,6 @@ func (w *Wallet) DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chainc
 	}, nil
 }
 
-func (wallet *Wallet) mixedTxFee(tx *TxInfoFromWallet) {
-
-}
-
 func (wallet *Wallet) decodeTxInputs(mtx *wire.MsgTx, walletInputs []*WalletInput) (inputs []*TxInput, totalWalletInputs, totalWalletUnmixedInputs int64) {
 	inputs = make([]*TxInput, len(mtx.TxIn))
 	unmixedAccountNumber := wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)

--- a/decodetx.go
+++ b/decodetx.go
@@ -20,7 +20,6 @@ func DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chaincfg.Params) (
 	if err != nil {
 		return nil, err
 	}
-	txType := wallet.TxTransactionType(msgTx)
 
 	// only use input/output amounts relating to wallet to correctly determine tx direction
 	var totalWalletInput, totalWalletOutput int64
@@ -49,15 +48,19 @@ func DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chaincfg.Params) (
 
 	isMixedTx, mixDenom, mixCount := txhelpers.IsMixTx(msgTx)
 
+	txType := txhelper.FormatTransactionType(wallet.TxTransactionType(msgTx))
+	if isMixedTx {
+		txType = txhelper.TxTypeMixed
+	}
+
 	return &Transaction{
 		WalletID:    walletTx.WalletID,
 		Hash:        msgTx.TxHash().String(),
-		Type:        txhelper.FormatTransactionType(txType),
+		Type:        txType,
 		Hex:         walletTx.Hex,
 		Timestamp:   walletTx.Timestamp,
 		BlockHeight: walletTx.BlockHeight,
 
-		IsMixed:         isMixedTx,
 		MixDenomination: mixDenom,
 		MixCount:        int32(mixCount),
 

--- a/decodetx.go
+++ b/decodetx.go
@@ -6,6 +6,7 @@ import (
 	"decred.org/dcrwallet/wallet"
 	"github.com/decred/dcrd/blockchain/stake/v3"
 	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/txscript/v3"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/txhelpers/v4"
@@ -15,42 +16,37 @@ import (
 const BlockValid = 1 << 0
 
 // DecodeTransaction uses `walletTx.Hex` to retrieve detailed information for a transaction.
-func DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chaincfg.Params) (*Transaction, error) {
+func (w *Wallet) DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chaincfg.Params) (*Transaction, error) {
 	msgTx, txFee, txSize, txFeeRate, err := txhelper.MsgTxFeeSizeRate(walletTx.Hex)
 	if err != nil {
 		return nil, err
 	}
 
-	// only use input/output amounts relating to wallet to correctly determine tx direction
-	var totalWalletInput, totalWalletOutput int64
-	for _, input := range walletTx.Inputs {
-		totalWalletInput += input.AmountIn
-	}
-	for _, output := range walletTx.Outputs {
-		totalWalletOutput += output.AmountOut
-	}
-	amount, direction := txhelper.TransactionAmountAndDirection(totalWalletInput, totalWalletOutput, int64(txFee))
+	inputs, totalWalletInput, totalWalletUnmixedInputs := w.decodeTxInputs(msgTx, walletTx.Inputs)
+	outputs, totalWalletOutput, totalWalletMixedOutputs, mixedOutputsCount := w.decodeTxOutputs(msgTx, netParams, walletTx.Outputs)
 
-	inputs := decodeTxInputs(msgTx, walletTx.Inputs)
-	outputs := decodeTxOutputs(msgTx, netParams, walletTx.Outputs)
+	amount, direction := txhelper.TransactionAmountAndDirection(totalWalletInput, totalWalletOutput, int64(txFee))
 
 	ssGenVersion, lastBlockValid, voteBits, ticketSpentHash := voteInfo(msgTx)
 
 	// ticketSpentHash will be empty if this isn't a vote tx
 	if stake.IsSSRtx(msgTx) {
 		ticketSpentHash = msgTx.TxIn[0].PreviousOutPoint.Hash.String()
-		// set first tx input ss amount for revoked txs
+		// set first tx input as amount for revoked txs
 		amount = msgTx.TxIn[0].ValueIn
 	} else if stake.IsSStx(msgTx) {
 		// set first tx output as amount for ticket txs
 		amount = msgTx.TxOut[0].Value
 	}
 
-	isMixedTx, mixDenom, mixCount := txhelpers.IsMixTx(msgTx)
+	isMixedTx, mixDenom, _ := txhelpers.IsMixTx(msgTx)
 
 	txType := txhelper.FormatTransactionType(wallet.TxTransactionType(msgTx))
 	if isMixedTx {
 		txType = txhelper.TxTypeMixed
+
+		mixChange := totalWalletOutput - totalWalletMixedOutputs
+		txFee = dcrutil.Amount(totalWalletUnmixedInputs - (totalWalletMixedOutputs + mixChange))
 	}
 
 	return &Transaction{
@@ -62,7 +58,7 @@ func DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chaincfg.Params) (
 		BlockHeight: walletTx.BlockHeight,
 
 		MixDenomination: mixDenom,
-		MixCount:        int32(mixCount),
+		MixCount:        mixedOutputsCount,
 
 		Version:  int32(msgTx.Version),
 		LockTime: int32(msgTx.LockTime),
@@ -83,8 +79,13 @@ func DecodeTransaction(walletTx *TxInfoFromWallet, netParams *chaincfg.Params) (
 	}, nil
 }
 
-func decodeTxInputs(mtx *wire.MsgTx, walletInputs []*WalletInput) (inputs []*TxInput) {
+func (wallet *Wallet) mixedTxFee(tx *TxInfoFromWallet) {
+
+}
+
+func (wallet *Wallet) decodeTxInputs(mtx *wire.MsgTx, walletInputs []*WalletInput) (inputs []*TxInput, totalWalletInputs, totalWalletUnmixedInputs int64) {
 	inputs = make([]*TxInput, len(mtx.TxIn))
+	unmixedAccountNumber := wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
 
 	for i, txIn := range mtx.TxIn {
 		input := &TxInput{
@@ -103,15 +104,24 @@ func decodeTxInputs(mtx *wire.MsgTx, walletInputs []*WalletInput) (inputs []*TxI
 			}
 		}
 
+		if input.AccountNumber != -1 {
+			totalWalletInputs += input.Amount
+			if input.AccountNumber == unmixedAccountNumber {
+				totalWalletUnmixedInputs += input.Amount
+			}
+		}
+
 		inputs[i] = input
 	}
 
 	return
 }
 
-func decodeTxOutputs(mtx *wire.MsgTx, netParams *chaincfg.Params, walletOutputs []*WalletOutput) (outputs []*TxOutput) {
+func (wallet *Wallet) decodeTxOutputs(mtx *wire.MsgTx, netParams *chaincfg.Params,
+	walletOutputs []*WalletOutput) (outputs []*TxOutput, totalWalletOutput, totalWalletMixedOutputs int64, mixedOutputsCount int32) {
 	outputs = make([]*TxOutput, len(mtx.TxOut))
 	txType := stake.DetermineTxType(mtx, true)
+	mixedAccountNumber := wallet.ReadInt32ConfigValueForKey(AccountMixerMixedAccount, -1)
 
 	for i, txOut := range mtx.TxOut {
 		// get address and script type for output
@@ -149,6 +159,14 @@ func decodeTxOutputs(mtx *wire.MsgTx, netParams *chaincfg.Params, walletOutputs 
 				output.Address = walletOutput.Address
 				output.AccountNumber = walletOutput.AccountNumber
 				break
+			}
+		}
+
+		if output.AccountNumber != -1 {
+			totalWalletOutput += output.Amount
+			if output.AccountNumber == mixedAccountNumber {
+				totalWalletMixedOutputs += output.Amount
+				mixedOutputsCount++
 			}
 		}
 

--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,7 @@ const (
 	ErrWalletLocked                 = "wallet_locked"
 	ErrWalletDatabaseInUse          = "wallet_db_in_use"
 	ErrWalletNotLoaded              = "wallet_not_loaded"
+	ErrWalletNotFound               = "wallet_not_found"
 	ErrWalletNameExist              = "wallet_name_exists"
 	ErrReservedWalletName           = "wallet_name_reserved"
 	ErrWalletIsRestored             = "wallet_is_restored"

--- a/politeia_client.go
+++ b/politeia_client.go
@@ -16,6 +16,7 @@ import (
 )
 
 type politeiaClient struct {
+	host       string
 	httpClient *http.Client
 
 	policy             *www.PolicyReply
@@ -25,9 +26,10 @@ type politeiaClient struct {
 }
 
 const (
-	host    = "https://proposals.decred.org"
-	apiPath = "/api/v1"
+	PoliteiaMainnetHost = "https://proposals.decred.org"
+	PoliteiaTestnetHost = "https://test-proposals.decred.org"
 
+	apiPath              = "/api/v1"
 	versionPath          = "/version"
 	policyPath           = "/policy"
 	votesStatusPath      = "/proposals/votestatus"
@@ -37,7 +39,7 @@ const (
 	batchVoteSummaryPath = "/proposals/batchvotesummary"
 )
 
-func newPoliteiaClient() *politeiaClient {
+func newPoliteiaClient(host string) *politeiaClient {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -50,6 +52,7 @@ func newPoliteiaClient() *politeiaClient {
 	}
 
 	return &politeiaClient{
+		host:       host,
 		httpClient: httpClient,
 	}
 }
@@ -87,7 +90,7 @@ func (c *politeiaClient) makeRequest(method, path string, body interface{}, dest
 		}
 	}
 
-	route := host + apiPath + path
+	route := c.host + apiPath + path
 	if body != nil {
 		requestBody, err = c.getRequestBody(method, body)
 		if err != nil {
@@ -165,7 +168,7 @@ func (c *politeiaClient) handleError(statusCode int, responseBody []byte) error 
 }
 
 func (c *politeiaClient) version() (*www.VersionReply, error) {
-	route := host + apiPath + versionPath
+	route := c.host + apiPath + versionPath
 	req, err := http.NewRequest(http.MethodGet, route, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating version request: %s", err.Error())

--- a/politeia_sync.go
+++ b/politeia_sync.go
@@ -15,7 +15,7 @@ const (
 )
 
 // Sync fetches all proposals from the server and
-func (p *Politeia) Sync() error {
+func (p *Politeia) Sync(host string) error {
 
 	p.mu.Lock()
 
@@ -27,7 +27,7 @@ func (p *Politeia) Sync() error {
 	log.Info("Politeia sync: started")
 
 	p.ctx, p.cancelSync = p.mwRef.contextWithShutdownCancel()
-	p.client = newPoliteiaClient()
+	p.client = newPoliteiaClient(host)
 	defer p.resetSyncData()
 
 	p.mu.Unlock()
@@ -334,7 +334,7 @@ func (p *Politeia) fetchBatchProposals(category int32, tokens []string, broadcas
 	return nil
 }
 
-func (p *Politeia) FetchProposalDescription(token string) (string, error) {
+func (p *Politeia) FetchProposalDescription(politeiaHost, token string) (string, error) {
 
 	proposal, err := p.GetProposalRaw(token)
 	if err != nil {
@@ -345,7 +345,7 @@ func (p *Politeia) FetchProposalDescription(token string) (string, error) {
 	client := p.client
 	p.mu.Unlock()
 	if client == nil {
-		client = newPoliteiaClient()
+		client = newPoliteiaClient(politeiaHost)
 		err := client.loadServerPolicy()
 		if err != nil {
 			return "", err

--- a/transactions.go
+++ b/transactions.go
@@ -20,6 +20,7 @@ const (
 	TxFilterStaking     = walletdata.TxFilterStaking
 	TxFilterCoinBase    = walletdata.TxFilterCoinBase
 	TxFilterRegular     = walletdata.TxFilterRegular
+	TxFilterMixed       = walletdata.TxFilterMixed
 
 	TxDirectionInvalid     = txhelper.TxDirectionInvalid
 	TxDirectionSent        = txhelper.TxDirectionSent
@@ -31,6 +32,7 @@ const (
 	TxTypeTicketPurchase = txhelper.TxTypeTicketPurchase
 	TxTypeVote           = txhelper.TxTypeVote
 	TxTypeRevocation     = txhelper.TxTypeRevocation
+	TxTypeMixed          = txhelper.TxTypeMixed
 )
 
 func (wallet *Wallet) PublishUnminedTransactions() error {

--- a/txauthor.go
+++ b/txauthor.go
@@ -28,12 +28,22 @@ type TxAuthor struct {
 	changeDestination   *TransactionDestination
 }
 
-func (mw *MultiWallet) NewUnsignedTx(sourceWallet *Wallet, sourceAccountNumber int32) *TxAuthor {
+func (mw *MultiWallet) NewUnsignedTx(walletID int, sourceAccountNumber int32) (*TxAuthor, error) {
+	sourceWallet := mw.WalletWithID(walletID)
+	if sourceWallet == nil {
+		return nil, fmt.Errorf(ErrWalletNotFound)
+	}
+
+	_, err := sourceWallet.GetAccount(sourceAccountNumber)
+	if err != nil {
+		return nil, err
+	}
+
 	return &TxAuthor{
 		sourceWallet:        sourceWallet,
 		sourceAccountNumber: uint32(sourceAccountNumber),
 		destinations:        make([]TransactionDestination, 0),
-	}
+	}, nil
 }
 
 func (tx *TxAuthor) AddSendDestination(address string, atomAmount int64, sendMax bool) error {

--- a/txhelper/types.go
+++ b/txhelper/types.go
@@ -7,6 +7,7 @@ const (
 	TxDirectionTransferred int32 = 2
 
 	TxTypeRegular        = "Regular"
+	TxTypeMixed          = "Mixed"
 	TxTypeCoinBase       = "Coinbase"
 	TxTypeTicketPurchase = "Ticket"
 	TxTypeVote           = "Vote"

--- a/txindex.go
+++ b/txindex.go
@@ -6,8 +6,6 @@ import (
 	"github.com/planetdecred/dcrlibwallet/walletdata"
 )
 
-const defaultTxRecoveryBlocks int32 = 4000
-
 func (wallet *Wallet) IndexTransactions() error {
 	ctx := wallet.shutdownContext()
 
@@ -73,7 +71,12 @@ func (wallet *Wallet) IndexTransactions() error {
 		if err != nil {
 			log.Errorf("[%d] Post-indexing tx count error :%v", wallet.ID, err)
 		} else if count > 0 {
-			log.Infof("[%d] Transaction index finished at %d, %d transaction(s) indexed in total", wallet.ID, txEndHeight, count)
+			log.Infof("[%d] Transaction index finished at %d, %d transaction(s) indexed in total", wallet.ID, endHeight, count)
+		}
+
+		err = wallet.walletDataDB.SaveLastIndexPoint(endHeight)
+		if err != nil {
+			log.Errorf("[%d] Set tx index end block height error: ", wallet.ID, err)
 		}
 	}()
 

--- a/txparser.go
+++ b/txparser.go
@@ -70,7 +70,7 @@ func (wallet *Wallet) decodeTransactionWithTxSummary(txSummary *w.TransactionSum
 		Outputs:     walletOutputs,
 	}
 
-	decodedTx, err := DecodeTransaction(walletTx, wallet.chainParams)
+	decodedTx, err := wallet.DecodeTransaction(walletTx, wallet.chainParams)
 	if err != nil {
 		return nil, err
 	}

--- a/types.go
+++ b/types.go
@@ -176,7 +176,6 @@ type Transaction struct {
 	Timestamp   int64  `json:"timestamp"`
 	BlockHeight int32  `json:"block_height"`
 
-	IsMixed         bool  `json:"is_mixed"`
 	MixDenomination int64 `json:"mix_denom"`
 	MixCount        int32 `json:"mix_count"`
 

--- a/vspd.go
+++ b/vspd.go
@@ -174,7 +174,10 @@ func (v *VSPD) CreateTicketFeeTx(feeAmount int64, ticketHash, feeAddress string,
 		return "", errors.New("vspd ticket fee has been created. Use PayVSPFee() to register ticket")
 	}
 
-	txAuthor := v.mwRef.NewUnsignedTx(v.w, v.sourceAccountNumber)
+	txAuthor, err := v.mwRef.NewUnsignedTx(v.w.ID, v.sourceAccountNumber)
+	if err != nil {
+		return "", err
+	}
 	txAuthor.AddSendDestination(feeAddress, feeAmount, false)
 
 	unsignedTx, err := txAuthor.constructTransaction()

--- a/walletdata/filter.go
+++ b/walletdata/filter.go
@@ -14,6 +14,7 @@ const (
 	TxFilterStaking     int32 = 4
 	TxFilterCoinBase    int32 = 5
 	TxFilterRegular     int32 = 6
+	TxFilterMixed       int32 = 7
 )
 
 func TxMatchesFilter(txType string, txDirection, txFilter int32) bool {
@@ -25,11 +26,22 @@ func TxMatchesFilter(txType string, txDirection, txFilter int32) bool {
 	case TxFilterTransferred:
 		return txType == txhelper.TxTypeRegular && txDirection == txhelper.TxDirectionTransferred
 	case TxFilterStaking:
-		return txType != txhelper.TxTypeRegular && txType != txhelper.TxTypeCoinBase
+		switch txType {
+		case txhelper.TxTypeTicketPurchase:
+			fallthrough
+		case txhelper.TxTypeVote:
+			fallthrough
+		case txhelper.TxTypeRevocation:
+			return true
+		}
+
+		return false
 	case TxFilterCoinBase:
 		return txType == txhelper.TxTypeCoinBase
 	case TxFilterRegular:
 		return txType == txhelper.TxTypeRegular
+	case TxFilterMixed:
+		return txType == txhelper.TxTypeMixed
 	case TxFilterAll:
 		return true
 	}
@@ -68,6 +80,10 @@ func (db *DB) prepareTxQuery(txFilter int32) (query storm.Query) {
 	case TxFilterRegular:
 		query = db.walletDataDB.Select(
 			q.Eq("Type", txhelper.TxTypeRegular),
+		)
+	case TxFilterMixed:
+		query = db.walletDataDB.Select(
+			q.Eq("Type", txhelper.TxTypeMixed),
 		)
 	default:
 		query = db.walletDataDB.Select(

--- a/walletdata/filter.go
+++ b/walletdata/filter.go
@@ -68,9 +68,10 @@ func (db *DB) prepareTxQuery(txFilter int32) (query storm.Query) {
 		)
 	case TxFilterStaking:
 		query = db.walletDataDB.Select(
-			q.Not(
-				q.Eq("Type", txhelper.TxTypeRegular),
-				q.Eq("Type", txhelper.TxTypeCoinBase),
+			q.Or(
+				q.Eq("Type", txhelper.TxTypeTicketPurchase),
+				q.Eq("Type", txhelper.TxTypeVote),
+				q.Eq("Type", txhelper.TxTypeRevocation),
 			),
 		)
 	case TxFilterCoinBase:


### PR DESCRIPTION
This change allows easy filtering of mixed transactions and the tx db version number is also incremented to enable wallets to reindex their transactions and correctly specify the tx type of old mixed transactions.