### PR TITLE
Add missing case in GeneralSyncProgress function

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -363,6 +363,8 @@ func (mw *MultiWallet) GeneralSyncProgress() *GeneralSyncProgress {
 			return mw.syncData.addressDiscoveryProgress.GeneralSyncProgress
 		case HeadersRescanSyncStage:
 			return mw.syncData.headersRescanProgress.GeneralSyncProgress
+		case CFiltersFetchSyncStage:
+			return mw.syncData.cfiltersFetchProgress.GeneralSyncProgress
 		}
 	}
 


### PR DESCRIPTION
This PR add missing case in GeneralSyncProgress  function to help mobile get notification when app in background