### PR TITLE
pass unique identifiers to the account mixer notification listeners

### DIFF
--- a/account_mixer.go
+++ b/account_mixer.go
@@ -22,8 +22,23 @@ const (
 	MixedAccountBranch = 0
 )
 
-func (mw *MultiWallet) SetAccountMixerNotification(accountMixerNotificationListener AccountMixerNotificationListener) {
-	mw.accountMixerNotificationListener = accountMixerNotificationListener
+func (mw *MultiWallet) AddAccountMixerNotificationListener(accountMixerNotificationListener AccountMixerNotificationListener, uniqueIdentifier string) error {
+	mw.notificationListenersMu.Lock()
+	defer mw.notificationListenersMu.Unlock()
+
+	if _, ok := mw.accountMixerNotificationListener[uniqueIdentifier]; ok {
+		return errors.New(ErrListenerAlreadyExist)
+	}
+
+	mw.accountMixerNotificationListener[uniqueIdentifier] = accountMixerNotificationListener
+	return nil
+}
+
+func (mw *MultiWallet) RemoveAccountMixerNotificationListener(uniqueIdentifier string) {
+	mw.notificationListenersMu.Lock()
+	defer mw.notificationListenersMu.Unlock()
+
+	delete(mw.accountMixerNotificationListener, uniqueIdentifier)
 }
 
 // CreateMixerAccounts creates the two accounts needed for the account mixer. This function
@@ -183,7 +198,7 @@ func (mw *MultiWallet) StartAccountMixer(walletID int, walletPassphrase string) 
 	go func() {
 		log.Info("Running account mixer")
 		if mw.accountMixerNotificationListener != nil {
-			mw.accountMixerNotificationListener.OnAccountMixerStarted(walletID)
+			mw.publishAccountMixerStarted(walletID)
 		}
 
 		ctx, cancel := mw.contextWithShutdownCancel()
@@ -195,7 +210,7 @@ func (mw *MultiWallet) StartAccountMixer(walletID int, walletPassphrase string) 
 
 		wallet.cancelAccountMixer = nil
 		if mw.accountMixerNotificationListener != nil {
-			mw.accountMixerNotificationListener.OnAccountMixerEnded(walletID)
+			mw.publishAccountMixerEnded(walletID)
 		}
 	}()
 
@@ -260,4 +275,22 @@ func (wallet *Wallet) accountHasMixableOutput(accountNumber int32) (bool, error)
 // IsAccountMixerActive returns true if account mixer is active
 func (wallet *Wallet) IsAccountMixerActive() bool {
 	return wallet.cancelAccountMixer != nil
+}
+
+func (mw *MultiWallet) publishAccountMixerStarted(walletID int) {
+	mw.notificationListenersMu.RLock()
+	defer mw.notificationListenersMu.RUnlock()
+
+	for _, accountMixerNotificationListener := range mw.accountMixerNotificationListener {
+		accountMixerNotificationListener.OnAccountMixerStarted(walletID)
+	}
+}
+
+func (mw *MultiWallet) publishAccountMixerEnded(walletID int) {
+	mw.notificationListenersMu.RLock()
+	defer mw.notificationListenersMu.RUnlock()
+
+	for _, accountMixerNotificationListener := range mw.accountMixerNotificationListener {
+		accountMixerNotificationListener.OnAccountMixerEnded(walletID)
+	}
 }

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -34,7 +34,7 @@ type MultiWallet struct {
 	txAndBlockNotificationListeners map[string]TxAndBlockNotificationListener
 
 	blocksRescanProgressListener     BlocksRescanProgressListener
-	accountMixerNotificationListener AccountMixerNotificationListener
+	accountMixerNotificationListener map[string]AccountMixerNotificationListener
 
 	shuttingDown chan bool
 	cancelFuncs  []context.CancelFunc
@@ -94,7 +94,8 @@ func NewMultiWallet(rootDir, dbDriver, netType string) (*MultiWallet, error) {
 		syncData: &syncData{
 			syncProgressListeners: make(map[string]SyncProgressListener),
 		},
-		txAndBlockNotificationListeners: make(map[string]TxAndBlockNotificationListener),
+		txAndBlockNotificationListeners:  make(map[string]TxAndBlockNotificationListener),
+		accountMixerNotificationListener: make(map[string]AccountMixerNotificationListener),
 	}
 
 	mw.Politeia, err = newPoliteia(mw)


### PR DESCRIPTION
Previously the Account Mixer Notification listeners weren't being called with unique identifiers, this caused newly opened pages to override the callback listeners set in previous pages. the resulting effect of this was the user's screen not going to sleep after the mixer had ended while they are on some pages of the app

This new change allows the callback listeners to be triggered simultaneously across all pages that calls it in the client app allowing the user's screen to sleep no matter what page they are viewing