### PR TITLE
Send mixed account transactions change to unmixed account

### DIFF
--- a/account_mixer.go
+++ b/account_mixer.go
@@ -110,6 +110,18 @@ func (wallet *Wallet) SetAccountMixerConfig(mixedAccount, unmixedAccount int32, 
 	return nil
 }
 
+func (wallet *Wallet) AccountMixerConfigIsSet() bool {
+	return wallet.ReadBoolConfigValueForKey(AccountMixerConfigSet, false)
+}
+
+func (wallet *Wallet) MixedAccountNumber() int32 {
+	return wallet.ReadInt32ConfigValueForKey(AccountMixerMixedAccount, -1)
+}
+
+func (wallet *Wallet) UnmixedAccountNumber() int32 {
+	return wallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)
+}
+
 func (wallet *Wallet) ClearMixerConfig() {
 	wallet.SetInt32ConfigValueForKey(AccountMixerMixedAccount, -1)
 	wallet.SetInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1)

--- a/account_mixer.go
+++ b/account_mixer.go
@@ -110,6 +110,10 @@ func (wallet *Wallet) SetAccountMixerConfig(mixedAccount, unmixedAccount int32, 
 	return nil
 }
 
+func (wallet *Wallet) AccountMixerMixChange() bool {
+	return wallet.ReadBoolConfigValueForKey(AccountMixerMixTxChange, false)
+}
+
 func (wallet *Wallet) AccountMixerConfigIsSet() bool {
 	return wallet.ReadBoolConfigValueForKey(AccountMixerConfigSet, false)
 }

--- a/txauthor.go
+++ b/txauthor.go
@@ -342,9 +342,10 @@ func (tx *TxAuthor) changeSource(ctx context.Context) (txauthor.ChangeSource, er
 	if tx.changeAddress == "" {
 		var changeAccount uint32
 
-		mixChange := tx.sourceWallet.ReadBoolConfigValueForKey(AccountMixerMixTxChange, false)
-		if mixChange {
-			changeAccount = uint32(tx.sourceWallet.ReadInt32ConfigValueForKey(AccountMixerUnmixedAccount, -1))
+		if tx.sourceWallet.AccountMixerConfigIsSet() {
+			if tx.sourceAccountNumber == uint32(tx.sourceWallet.MixedAccountNumber()) {
+				changeAccount = uint32(tx.sourceWallet.UnmixedAccountNumber())
+			}
 		} else {
 			changeAccount = tx.sourceAccountNumber
 		}

--- a/types.go
+++ b/types.go
@@ -23,6 +23,7 @@ type Amount struct {
 
 type TxFeeAndSize struct {
 	Fee                 *Amount
+	Change              *Amount
 	EstimatedSignedSize int
 }
 

--- a/wallet_config.go
+++ b/wallet_config.go
@@ -9,6 +9,7 @@ const (
 	AccountMixerConfigSet      = "account_mixer_config_set"
 	AccountMixerMixedAccount   = "account_mixer_mixed_account"
 	AccountMixerUnmixedAccount = "account_mixer_unmixed_account"
+	AccountMixerMixTxChange    = "account_mixer_mix_tx_change"
 )
 
 func (wallet *Wallet) SaveUserConfigValue(key string, value interface{}) {

--- a/wallet_config.go
+++ b/wallet_config.go
@@ -9,7 +9,6 @@ const (
 	AccountMixerConfigSet      = "account_mixer_config_set"
 	AccountMixerMixedAccount   = "account_mixer_mixed_account"
 	AccountMixerUnmixedAccount = "account_mixer_unmixed_account"
-	AccountMixerMixTxChange    = "account_mixer_mix_tx_change"
 )
 
 func (wallet *Wallet) SaveUserConfigValue(key string, value interface{}) {


### PR DESCRIPTION
Sending the change of transactions created from the mixed account to unmixed will allow the change coins to be mixed before spending.