### PR TITLE
Add transaction and staking overview

### DIFF
--- a/ticket.go
+++ b/ticket.go
@@ -36,13 +36,8 @@ func (wallet *Wallet) StakeInfo() (*w.StakeInfoData, error) {
 	return wallet.internal.StakeInfo(ctx)
 }
 
-func (wallet *Wallet) StakingOverview() (*StakingOverview, error) {
-	stOverview := &StakingOverview{}
-
-	stakeInfo, err := wallet.StakeInfo()
-	if err != nil {
-		return nil, err
-	}
+func (wallet *Wallet) StakingOverview() (stOverview *StakingOverview, err error) {
+	stOverview = &StakingOverview{}
 
 	stOverview.Voted, err = wallet.CountTransactions(TxFilterVoted)
 	if err != nil {
@@ -54,14 +49,23 @@ func (wallet *Wallet) StakingOverview() (*StakingOverview, error) {
 		return nil, err
 	}
 
-	stOverview.Mempool = int(stakeInfo.OwnMempoolTix)
-	stOverview.Immature = int(stakeInfo.Immature)
-	stOverview.Live = int(stakeInfo.Live)
-	stOverview.Missed = int(stakeInfo.Missed)
-	stOverview.Expired = int(stakeInfo.UnspentExpired)
+	stOverview.Expired, err = wallet.CountTransactions(TxFilterExpired)
+	if err != nil {
+		return nil, err
+	}
 
-	stOverview.All = stOverview.Mempool + stOverview.Immature + stOverview.Live + stOverview.Voted +
-		stOverview.Missed + stOverview.Expired + stOverview.Revoked
+	stOverview.Live, err = wallet.CountTransactions(TxFilterLive)
+	if err != nil {
+		return nil, err
+	}
+
+	stOverview.Immature, err = wallet.CountTransactions(TxFilterImmature)
+	if err != nil {
+		return nil, err
+	}
+
+	stOverview.All = stOverview.Immature + stOverview.Live + stOverview.Voted +
+		stOverview.Expired + stOverview.Revoked
 
 	return stOverview, nil
 }

--- a/ticket.go
+++ b/ticket.go
@@ -58,7 +58,7 @@ func (wallet *Wallet) StakingOverview() (*StakingOverview, error) {
 	stOverview.Immature = int(stakeInfo.Immature)
 	stOverview.Live = int(stakeInfo.Live)
 	stOverview.Missed = int(stakeInfo.Missed)
-	stOverview.Expired = int(stakeInfo.Expired)
+	stOverview.Expired = int(stakeInfo.UnspentExpired)
 
 	stOverview.All = stOverview.Mempool + stOverview.Immature + stOverview.Live + stOverview.Voted +
 		stOverview.Missed + stOverview.Expired + stOverview.Revoked

--- a/ticket.go
+++ b/ticket.go
@@ -36,6 +36,36 @@ func (wallet *Wallet) StakeInfo() (*w.StakeInfoData, error) {
 	return wallet.internal.StakeInfo(ctx)
 }
 
+func (wallet *Wallet) StakingOverview() (*StakingOverview, error) {
+	stOverview := &StakingOverview{}
+
+	stakeInfo, err := wallet.StakeInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	stOverview.Voted, err = wallet.CountTransactions(TxFilterVoted)
+	if err != nil {
+		return nil, err
+	}
+
+	stOverview.Revoked, err = wallet.CountTransactions(TxFilterRevoked)
+	if err != nil {
+		return nil, err
+	}
+
+	stOverview.Mempool = int(stakeInfo.OwnMempoolTix)
+	stOverview.Immature = int(stakeInfo.Immature)
+	stOverview.Live = int(stakeInfo.Live)
+	stOverview.Missed = int(stakeInfo.Missed)
+	stOverview.Expired = int(stakeInfo.Expired)
+
+	stOverview.All = stOverview.Mempool + stOverview.Immature + stOverview.Live + stOverview.Voted +
+		stOverview.Missed + stOverview.Expired + stOverview.Revoked
+
+	return stOverview, nil
+}
+
 func (wallet *Wallet) GetTickets(startingBlockHash, endingBlockHash []byte, targetCount int32) ([]*TicketInfo, error) {
 	return wallet.getTickets(&GetTicketsRequest{
 		StartingBlockHash: startingBlockHash,

--- a/txindex.go
+++ b/txindex.go
@@ -67,7 +67,7 @@ func (wallet *Wallet) IndexTransactions() error {
 	endBlock := w.NewBlockIdentifierFromHeight(endHeight)
 
 	defer func() {
-		count, err := wallet.walletDataDB.Count(walletdata.TxFilterAll, &Transaction{})
+		count, err := wallet.walletDataDB.Count(walletdata.TxFilterAll, endHeight, &Transaction{})
 		if err != nil {
 			log.Errorf("[%d] Post-indexing tx count error :%v", wallet.ID, err)
 		} else if count > 0 {

--- a/txparser.go
+++ b/txparser.go
@@ -106,6 +106,10 @@ func (wallet *Wallet) decodeTransactionWithTxSummary(txSummary *w.TransactionSum
 
 		reward := ticketOutput - ticketInvestment
 		decodedTx.VoteReward = reward
+
+		// update ticket with spender hash
+		ticketPurchaseTx.TicketSpender = decodedTx.Hash
+		wallet.walletDataDB.SaveOrUpdate(&Transaction{}, ticketPurchaseTx)
 	}
 
 	return decodedTx, nil

--- a/types.go
+++ b/types.go
@@ -322,7 +322,6 @@ type VSPTicketPurchaseInfo struct {
 	TicketAddress string
 }
 
-// mixer overview
 type StakingOverview struct {
 	All      int
 	Immature int

--- a/types.go
+++ b/types.go
@@ -175,12 +175,13 @@ type BlocksRescanProgressListener interface {
 // Transaction is used with storm for tx indexing operations.
 // For faster queries, the `Hash`, `Type` and `Direction` fields are indexed.
 type Transaction struct {
-	WalletID    int    `json:"walletID"`
-	Hash        string `storm:"id,unique" json:"hash"`
-	Type        string `storm:"index" json:"type"`
-	Hex         string `json:"hex"`
-	Timestamp   int64  `storm:"index" json:"timestamp"`
-	BlockHeight int32  `storm:"index" json:"block_height"`
+	WalletID      int    `json:"walletID"`
+	Hash          string `storm:"id,unique" json:"hash"`
+	Type          string `storm:"index" json:"type"`
+	Hex           string `json:"hex"`
+	Timestamp     int64  `storm:"index" json:"timestamp"`
+	BlockHeight   int32  `storm:"index" json:"block_height"`
+	TicketSpender string `storm:"index" json:"ticket_spender"`
 
 	MixDenomination int64 `json:"mix_denom"`
 	MixCount        int32 `json:"mix_count"`

--- a/types.go
+++ b/types.go
@@ -325,11 +325,9 @@ type VSPTicketPurchaseInfo struct {
 // mixer overview
 type StakingOverview struct {
 	All      int
-	Mempool  int
 	Immature int
 	Live     int
 	Voted    int
-	Missed   int
 	Expired  int
 	Revoked  int
 }

--- a/types.go
+++ b/types.go
@@ -179,8 +179,8 @@ type Transaction struct {
 	Hash        string `storm:"id,unique" json:"hash"`
 	Type        string `storm:"index" json:"type"`
 	Hex         string `json:"hex"`
-	Timestamp   int64  `json:"timestamp"`
-	BlockHeight int32  `json:"block_height"`
+	Timestamp   int64  `storm:"index" json:"timestamp"`
+	BlockHeight int32  `storm:"index" json:"block_height"`
 
 	MixDenomination int64 `json:"mix_denom"`
 	MixCount        int32 `json:"mix_count"`
@@ -260,6 +260,16 @@ type TransactionDestination struct {
 	SendMax    bool
 }
 
+type TransactionOverview struct {
+	All         int
+	Sent        int
+	Received    int
+	Transferred int
+	Mixed       int
+	Staking     int
+	Coinbase    int
+}
+
 /** end tx-related types */
 
 /** begin ticket-related types */
@@ -309,6 +319,18 @@ type VSPTicketPurchaseInfo struct {
 	PoolFees      float64
 	Script        string
 	TicketAddress string
+}
+
+// mixer overview
+type StakingOverview struct {
+	All      int
+	Mempool  int
+	Immature int
+	Live     int
+	Voted    int
+	Missed   int
+	Expired  int
+	Revoked  int
 }
 
 /** end ticket-related types */

--- a/wallet.go
+++ b/wallet.go
@@ -69,7 +69,7 @@ func (wallet *Wallet) prepare(rootDir string, chainParams *chaincfg.Params,
 	if exists, _ := fileExists(oldTxDBPath); exists {
 		moveFile(oldTxDBPath, walletDataDBPath)
 	}
-	wallet.walletDataDB, err = walletdata.Initialize(walletDataDBPath, &Transaction{}, &VspdTicketInfo{})
+	wallet.walletDataDB, err = walletdata.Initialize(walletDataDBPath, chainParams, &Transaction{}, &VspdTicketInfo{})
 	if err != nil {
 		log.Error(err.Error())
 		return err

--- a/walletdata/db.go
+++ b/walletdata/db.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/asdine/storm"
+	"github.com/decred/dcrd/chaincfg/v3"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -22,6 +23,7 @@ const (
 
 type DB struct {
 	walletDataDB *storm.DB
+	chainParams  *chaincfg.Params
 	Close        func() error
 }
 
@@ -29,7 +31,7 @@ type DB struct {
 // and checks the database version for compatibility.
 // If there is a version mismatch or the db does not exist at `dbPath`,
 // a new db is created and the current db version number saved to the db.
-func Initialize(dbPath string, txData, vspdData interface{}) (*DB, error) {
+func Initialize(dbPath string, chainParams *chaincfg.Params, txData, vspdData interface{}) (*DB, error) {
 	walletDataDB, err := openOrCreateDB(dbPath)
 	if err != nil {
 		return nil, err
@@ -54,6 +56,7 @@ func Initialize(dbPath string, txData, vspdData interface{}) (*DB, error) {
 
 	return &DB{
 		walletDataDB,
+		chainParams,
 		walletDataDB.Close,
 	}, nil
 }

--- a/walletdata/db.go
+++ b/walletdata/db.go
@@ -18,7 +18,7 @@ const (
 
 	// TxDbVersion is necessary to force re-indexing if changes are made to the structure of data being stored.
 	// Increment this version number if db structure changes such that client apps need to re-index.
-	TxDbVersion uint32 = 2
+	TxDbVersion uint32 = 3
 )
 
 type DB struct {

--- a/walletdata/filter.go
+++ b/walletdata/filter.go
@@ -17,45 +17,11 @@ const (
 	TxFilterMixed       int32 = 7
 	TxFilterVoted       int32 = 8
 	TxFilterRevoked     int32 = 9
+	TxFilterLive        int32 = 10
+	TxFilterExpired     int32 = 11
 )
 
-func TxMatchesFilter(txType string, txDirection, txFilter int32) bool {
-	switch txFilter {
-	case TxFilterSent:
-		return txType == txhelper.TxTypeRegular && txDirection == txhelper.TxDirectionSent
-	case TxFilterReceived:
-		return txType == txhelper.TxTypeRegular && txDirection == txhelper.TxDirectionReceived
-	case TxFilterTransferred:
-		return txType == txhelper.TxTypeRegular && txDirection == txhelper.TxDirectionTransferred
-	case TxFilterStaking:
-		switch txType {
-		case txhelper.TxTypeTicketPurchase:
-			fallthrough
-		case txhelper.TxTypeVote:
-			fallthrough
-		case txhelper.TxTypeRevocation:
-			return true
-		}
-
-		return false
-	case TxFilterCoinBase:
-		return txType == txhelper.TxTypeCoinBase
-	case TxFilterRegular:
-		return txType == txhelper.TxTypeRegular
-	case TxFilterMixed:
-		return txType == txhelper.TxTypeMixed
-	case TxFilterVoted:
-		return txType == txhelper.TxTypeVote
-	case TxFilterRevoked:
-		return txType == txhelper.TxTypeRevocation
-	case TxFilterAll:
-		return true
-	}
-
-	return false
-}
-
-func (db *DB) prepareTxQuery(txFilter int32) (query storm.Query) {
+func (db *DB) prepareTxQuery(txFilter, bestBlock int32) (query storm.Query) {
 	switch txFilter {
 	case TxFilterSent:
 		query = db.walletDataDB.Select(
@@ -99,6 +65,28 @@ func (db *DB) prepareTxQuery(txFilter int32) (query storm.Query) {
 	case TxFilterRevoked:
 		query = db.walletDataDB.Select(
 			q.Eq("Type", txhelper.TxTypeRevocation),
+		)
+	case TxFilterLive:
+		query = db.walletDataDB.Select(
+			q.And(
+				q.Eq("Type", txhelper.TxTypeTicketPurchase),
+				q.Eq("TicketSpender", ""),
+				q.Or(
+					q.Gte("Expiry", bestBlock),
+					q.Eq("Expiry", 0),
+				),
+			),
+		)
+	case TxFilterExpired:
+		query = db.walletDataDB.Select(
+			q.And(
+				q.Eq("Type", txhelper.TxTypeTicketPurchase),
+				q.Eq("TicketSpender", ""),
+				q.And(
+					q.Lte("Expiry", bestBlock),
+					q.Not(q.Eq("Expiry", 0)),
+				),
+			),
 		)
 	default:
 		query = db.walletDataDB.Select(

--- a/walletdata/filter.go
+++ b/walletdata/filter.go
@@ -15,6 +15,8 @@ const (
 	TxFilterCoinBase    int32 = 5
 	TxFilterRegular     int32 = 6
 	TxFilterMixed       int32 = 7
+	TxFilterVoted       int32 = 8
+	TxFilterRevoked     int32 = 9
 )
 
 func TxMatchesFilter(txType string, txDirection, txFilter int32) bool {
@@ -42,6 +44,10 @@ func TxMatchesFilter(txType string, txDirection, txFilter int32) bool {
 		return txType == txhelper.TxTypeRegular
 	case TxFilterMixed:
 		return txType == txhelper.TxTypeMixed
+	case TxFilterVoted:
+		return txType == txhelper.TxTypeVote
+	case TxFilterRevoked:
+		return txType == txhelper.TxTypeRevocation
 	case TxFilterAll:
 		return true
 	}
@@ -85,6 +91,14 @@ func (db *DB) prepareTxQuery(txFilter int32) (query storm.Query) {
 	case TxFilterMixed:
 		query = db.walletDataDB.Select(
 			q.Eq("Type", txhelper.TxTypeMixed),
+		)
+	case TxFilterVoted:
+		query = db.walletDataDB.Select(
+			q.Eq("Type", txhelper.TxTypeVote),
+		)
+	case TxFilterRevoked:
+		query = db.walletDataDB.Select(
+			q.Eq("Type", txhelper.TxTypeRevocation),
 		)
 	default:
 		query = db.walletDataDB.Select(


### PR DESCRIPTION
- Add tx filters for voted and revoked tickets.
- Add function to get ticket spender transaction.
- Add transaction timestamp and block height to storm index

This adds functions for getting transaction and staking overview which returns a summary count of different transaction and staking filters.