### PR TITLE
dexdcr: bump dcrlibwallet require version

### DIFF
--- a/dexdcr/go.mod
+++ b/dexdcr/go.mod
@@ -32,13 +32,11 @@ require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jrick/bitset v1.0.0 // indirect
 	github.com/jrick/wsrpc/v2 v2.3.4 // indirect
-	github.com/planetdecred/dcrlibwallet v0.0.0-00010101000000-000000000000
+	github.com/planetdecred/dcrlibwallet v1.6.2-0.20211102093800-0ba0a60df378
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210903071746-97244b99971b // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect
 )
-
-replace github.com/planetdecred/dcrlibwallet => ../
 
 go 1.17

--- a/dexdcr/go.sum
+++ b/dexdcr/go.sum
@@ -822,6 +822,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20211102093800-0ba0a60df378 h1:YLXP2+yzHQfSSNpcCPWeyKqaBKHTp7R/JGBDY3pIsUw=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20211102093800-0ba0a60df378/go.mod h1:bLX/rEGlGDEqZtcqArbAmUsDwJ3WMboUQpJ5gLwDqEU=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=


### PR DESCRIPTION
Remove the replace directive that was pointing to a local dcrlibwallet directory which prevents downloading the dexdcr module with `go get github.com/planetdecred/dcrlibwallet/dexdcr@master`.