### PR TITLE
add async tx and block notification listeners

### DIFF
--- a/txandblocknotifications.go
+++ b/txandblocknotifications.go
@@ -74,7 +74,17 @@ func (mw *MultiWallet) listenForTransactions(walletID int) {
 	}()
 }
 
-func (mw *MultiWallet) AddTxAndBlockNotificationListener(txAndBlockNotificationListener TxAndBlockNotificationListener, uniqueIdentifier string) error {
+// AddTxAndBlockNotificationListener registers a set of functions to be invoked
+// when a transaction or block update is processed by the wallet. If async is
+// true, the provided callback methods will be called from separate goroutines,
+// allowing notification senders to continue their operation without waiting
+// for the listener to complete processing the notification. This asyncrhonous
+// handling is especially important for cases where the wallet process that
+// sends the notification temporarily prevents access to other wallet features
+// until all notification handlers finish processing the notification. If a
+// notification handler were to try to access such features, it would result
+// in a deadlock.
+func (mw *MultiWallet) AddTxAndBlockNotificationListener(txAndBlockNotificationListener TxAndBlockNotificationListener, async bool, uniqueIdentifier string) error {
 	mw.notificationListenersMu.Lock()
 	defer mw.notificationListenersMu.Unlock()
 
@@ -83,7 +93,13 @@ func (mw *MultiWallet) AddTxAndBlockNotificationListener(txAndBlockNotificationL
 		return errors.New(ErrListenerAlreadyExist)
 	}
 
-	mw.txAndBlockNotificationListeners[uniqueIdentifier] = txAndBlockNotificationListener
+	if async {
+		mw.txAndBlockNotificationListeners[uniqueIdentifier] = &asyncTxAndBlockNotificationListener{
+			l: txAndBlockNotificationListener,
+		}
+	} else {
+		mw.txAndBlockNotificationListeners[uniqueIdentifier] = txAndBlockNotificationListener
+	}
 
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -167,6 +167,33 @@ type TxAndBlockNotificationListener interface {
 	OnTransactionConfirmed(walletID int, hash string, blockHeight int32)
 }
 
+// asyncTxAndBlockNotificationListener is a TxAndBlockNotificationListener that
+// triggers notifcation callbacks asynchronously.
+type asyncTxAndBlockNotificationListener struct {
+	l TxAndBlockNotificationListener
+}
+
+// OnTransaction satisfies the TxAndBlockNotificationListener interface and
+// starts a goroutine to actually handle the notification using the embedded
+// listener.
+func (asyncTxBlockListener *asyncTxAndBlockNotificationListener) OnTransaction(transaction string) {
+	go asyncTxBlockListener.l.OnTransaction(transaction)
+}
+
+// OnBlockAttached satisfies the TxAndBlockNotificationListener interface and
+// starts a goroutine to actually handle the notification using the embedded
+// listener.
+func (asyncTxBlockListener *asyncTxAndBlockNotificationListener) OnBlockAttached(walletID int, blockHeight int32) {
+	go asyncTxBlockListener.l.OnBlockAttached(walletID, blockHeight)
+}
+
+// OnTransactionConfirmed satisfies the TxAndBlockNotificationListener interface
+// and starts a goroutine to actually handle the notification using the embedded
+// listener.
+func (asyncTxBlockListener *asyncTxAndBlockNotificationListener) OnTransactionConfirmed(walletID int, hash string, blockHeight int32) {
+	go asyncTxBlockListener.l.OnTransactionConfirmed(walletID, hash, blockHeight)
+}
+
 type BlocksRescanProgressListener interface {
 	OnBlocksRescanStarted(walletID int)
 	OnBlocksRescanProgress(*HeadersRescanProgressReport)


### PR DESCRIPTION
Prevent potential deadlocks by making provision for tx and
block notification callbacks to be invoked asynchronously.

One such deadlock scenario that necessitated this change was
the wallet ticket purchse function blocking access to the
wallet balance method while sending a new transaction ntfn,
and a new tx ntfn handler tried to synchronously fetch the
wallet balance. The handler could not fetch the wallet balance
because it is blocked by the ticket purchase function and the
ticket purchase function could not complete its process and
unlock the wallet balance feature because it was waiting for
the ntfn handler to complete.