### PR TITLE
get wallet deployement/activation block height

### DIFF
--- a/multiwallet_utils.go
+++ b/multiwallet_utils.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"decred.org/dcrwallet/v2/deployments"
 	"decred.org/dcrwallet/v2/errors"
 	w "decred.org/dcrwallet/v2/wallet"
 	"github.com/asdine/storm"
@@ -106,6 +108,22 @@ func (mw *MultiWallet) RootDirFileSizeInBytes() (int64, error) {
 		return err
 	})
 	return size, err
+}
+
+// DCP0001ActivationBlockHeight returns the hardcoded block height that
+// the DCP0001 deployment activates at. DCP0001 specifies hard forking
+// changes to the stake difficulty algorithm.
+func (mw *MultiWallet) DCP0001ActivationBlockHeight() int32 {
+	var activationHeight int32 = -1
+	switch strings.ToLower(mw.chainParams.Name) {
+	case strings.ToLower(Mainnet):
+		activationHeight = deployments.DCP0001.MainNetActivationHeight
+	case strings.ToLower(Testnet3):
+		activationHeight = deployments.DCP0001.TestNet3ActivationHeight
+	default:
+	}
+
+	return activationHeight
 }
 
 // naclLoadFromPass derives a nacl.Key from pass using scrypt.Key.

--- a/sync.go
+++ b/sync.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"sync"
 
+	"decred.org/dcrwallet/v2/deployments"
 	"decred.org/dcrwallet/v2/errors"
 	"decred.org/dcrwallet/v2/p2p"
 	w "decred.org/dcrwallet/v2/wallet"
 	"github.com/decred/dcrd/addrmgr/v2"
+	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/planetdecred/dcrlibwallet/spv"
 )
 
@@ -490,4 +492,17 @@ func (mw *MultiWallet) GetLowestBlockTimestamp() int64 {
 		}
 	}
 	return timestamp
+}
+
+func (mw *MultiWallet) GetActivationBlockHeight() int32 {
+	var activationHeight int32 = -1
+	switch strings.ToLower(mw.chainParams.Name) {
+	case strings.ToLower(chaincfg.MainNetParams().Name):
+		activationHeight = deployments.DCP0001.MainNetActivationHeight
+	case strings.ToLower(chaincfg.TestNet3Params().Name):
+		activationHeight = deployments.DCP0001.TestNet3ActivationHeight
+	default:
+	}
+
+	return activationHeight
 }

--- a/sync.go
+++ b/sync.go
@@ -9,12 +9,10 @@ import (
 	"strings"
 	"sync"
 
-	"decred.org/dcrwallet/v2/deployments"
 	"decred.org/dcrwallet/v2/errors"
 	"decred.org/dcrwallet/v2/p2p"
 	w "decred.org/dcrwallet/v2/wallet"
 	"github.com/decred/dcrd/addrmgr/v2"
-	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/planetdecred/dcrlibwallet/spv"
 )
 
@@ -492,17 +490,4 @@ func (mw *MultiWallet) GetLowestBlockTimestamp() int64 {
 		}
 	}
 	return timestamp
-}
-
-func (mw *MultiWallet) GetActivationBlockHeight() int32 {
-	var activationHeight int32 = -1
-	switch strings.ToLower(mw.chainParams.Name) {
-	case strings.ToLower(chaincfg.MainNetParams().Name):
-		activationHeight = deployments.DCP0001.MainNetActivationHeight
-	case strings.ToLower(chaincfg.TestNet3Params().Name):
-		activationHeight = deployments.DCP0001.TestNet3ActivationHeight
-	default:
-	}
-
-	return activationHeight
 }


### PR DESCRIPTION
This Pr gets the wallet activation/deployment block height.
This aim to prevent the godcr error `wallet.NextStakeDifficulty: inactive deployment: DCP0001 is not known to be active` when getting ticket price from a wallet when it has not reached the sync activation height on mainnet network.