### PR TITLE
update the url endpoint for installing the golint binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: go build
 
       - name: Install linter
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.0"
 
       - name: Test and Lint
         env:


### PR DESCRIPTION
the install section of the official golangci-lint website(https://golangci-lint.run/usage/install/) shows there's a new URL used to install the golangci-lint binary which is https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh the dcrlibwallet workflow was attempting to use https://install.goreleaser.com/github.com/golangci/golangci-lint.sh, which is an old method of installing the binary and no longer works, causing the workflow to fail

The fix was to replace the outdated URL with the one recommended from the golangci-lint website